### PR TITLE
Fix-crash-on-advNew

### DIFF
--- a/src/controller/gController/GController.py
+++ b/src/controller/gController/GController.py
@@ -109,13 +109,18 @@ class GController():
         dlg = self.window.newDialog
         baseWord = str(dlg.baseWrd.text()).lower()
         keyLetter = str(dlg.keyLett.currentText()).lower()
-        print(f'\nBaseword: {baseWord}\n KeyLetter: {keyLetter}\n')
-        self.puzzle = MakePuzzle.newPuzzle(baseWord, keyLetter, self.outty, True)
-        self.puzzle.shuffleChars()
-        self.window.newGame(self.puzzle)
-        dlg.baseWrd.clear()
-        self.window.setStatus(self.outty.getField)
-        dlg.accept()
+
+        if len([*baseWord]) <= 7:
+            dlg.setMessage('')
+            print(f'\nBaseword: {baseWord}\n KeyLetter: {keyLetter}\n')
+            self.puzzle = MakePuzzle.newPuzzle(baseWord, keyLetter, self.outty, True)
+            self.puzzle.shuffleChars()
+            self.window.newGame(self.puzzle)
+            dlg.baseWrd.clear()
+            self.window.setStatus(self.outty.getField())
+            dlg.accept()
+        else:
+            dlg.setMessage('Invalid base word')
     ################################################################################
     # guess(window: object) -> None
     #

--- a/src/controller/gController/GController.py
+++ b/src/controller/gController/GController.py
@@ -110,7 +110,7 @@ class GController():
         baseWord = str(dlg.baseWrd.text()).lower()
         keyLetter = str(dlg.keyLett.currentText()).lower()
 
-        if len([*baseWord]) <= 7:
+        if len([*baseWord]) == 7:
             dlg.setMessage('')
             print(f'\nBaseword: {baseWord}\n KeyLetter: {keyLetter}\n')
             self.puzzle = MakePuzzle.newPuzzle(baseWord, keyLetter, self.outty, True)

--- a/src/gview/Dialogs.py
+++ b/src/gview/Dialogs.py
@@ -110,7 +110,8 @@ class NewDialog(QDialog):
          self.warningMsg = QLabel(self)
          self.advBtn = QPushButton(self)
          self.backBtn = QPushButton(self)
-
+         
+         self.advMsg = QLabel(self)
          self.baseWrd = QLineEdit(self)
          self.keyLett = QComboBox(self)
 
@@ -223,7 +224,8 @@ class NewDialog(QDialog):
              QSpacerItem(5, 0, QSizePolicy.Policy.MinimumExpanding)
          )
          backLayout.addWidget(self.backBtn)
-
+         
+         form.addRow('', self.advMsg)
          form.addRow('Baseword:', self.baseWrd)
          form.addRow('Key Letter:', self.keyLett)
 
@@ -240,7 +242,8 @@ class NewDialog(QDialog):
          for l in uniqueLett:
              self.keyLett.addItem(l.upper())
 
-
+     def setMessage(self, text: str) -> None:
+         self.advMsg.setText(text)
 
      def display(self, i : int=0) -> None:
          self.stack.setCurrentIndex(i)


### PR DESCRIPTION
new dialog no longer crashes on custom game

new dialog will now only accept basewords with exactly 7 unique letters. If there are < or > 7 unique letters, new game is blocked and "invalid base word" is displayed above "baseword" field.