### PR TITLE
Removed excessive output from terminal

### DIFF
--- a/src/gview/HexCluster.py
+++ b/src/gview/HexCluster.py
@@ -266,9 +266,9 @@ class HexButton(QPushButton):
     #     - event signaling repaint of button
     ############################################################################
     def paintEvent(self, event) -> None:
-        painter = QPainter(self)
-        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        painter = QPainter()
         painter.begin(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
         self._drawHex(painter)
         self._drawText(painter)
         painter.end()


### PR DESCRIPTION
'painter already active' message was caused by constructing the painter object with parent=self.